### PR TITLE
Enable s3 state locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Before you start provisioning the infrastructure in this repository, you'll want
        # ^^^^^ Replace this ^^^^^^
        key            = "${path_relative_to_include()}/tf.tfstate"
        region         = local.aws_region
-       dynamodb_table = "tf-locks"
+       use_lockfile   = true
      }
      generate = {
        path      = "backend.tf"

--- a/root.hcl
+++ b/root.hcl
@@ -39,7 +39,7 @@ remote_state {
     bucket         = "${get_env("TG_BUCKET_PREFIX", "")}terragrunt-example-tf-state-${local.account_name}-${local.aws_region}"
     key            = "${path_relative_to_include()}/tf.tfstate"
     region         = local.aws_region
-    dynamodb_table = "tf-locks"
+    use_lockfile  = true
   }
   generate = {
     path      = "backend.tf"


### PR DESCRIPTION
Enabling S3 State Locking

To enable S3 state locking, use the following optional argument:

 [use_lockfile](https://developer.hashicorp.com/terraform/language/backend/s3#use_lockfile) - (Optional) Whether to use a lockfile for locking the state file. Defaults to false.

Enabling DynamoDB State Locking (Deprecated)

To enable DynamoDB state locking, use the following optional arguments:

 [dynamodb_endpoint](https://developer.hashicorp.com/terraform/language/backend/s3#dynamodb_endpoint) - (Optional, Deprecated) Custom endpoint URL for the AWS DynamoDB API. Use endpoints.dynamodb instead.
 [dynamodb_table](https://developer.hashicorp.com/terraform/language/backend/s3#dynamodb_table) - (Optional, Deprecated) Name of the DynamoDB Table to use for state locking and consistency. The table must have a partition key named LockID with a type of String.

---

Reference:
https://developer.hashicorp.com/terraform/language/backend/s3#enabling-s3-state-locking
