### PR TITLE
Add Lambda function: example-lambda3 (non-prod/us-west-2)

### DIFF
--- a/non-prod/us-west-2/example-lambda3/src/app.py
+++ b/non-prod/us-west-2/example-lambda3/src/app.py
@@ -1,0 +1,69 @@
+"""
+Lambda function handler for the example-lambda3-non-prod function.
+"""
+
+import json
+import logging
+import os
+
+# Configure logging
+logger = logging.getLogger()
+logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
+
+
+def handler(event, context):
+    """
+    Main Lambda handler function.
+
+    Args:
+        event: The event data passed to the Lambda function.
+               This could be from API Gateway, S3, SNS, CloudWatch Events, etc.
+        context: The Lambda runtime context object containing metadata
+                 about the invocation, function, and execution environment.
+
+    Returns:
+        dict: A response object with statusCode and body for API Gateway,
+              or any JSON-serializable object for other triggers.
+    """
+    logger.info("Received event: %s", json.dumps(event))
+
+    # Extract request details if coming from API Gateway
+    http_method = event.get("httpMethod", "N/A")
+    path = event.get("path", "/")
+    query_params = event.get("queryStringParameters") or {}
+    body = event.get("body")
+
+    # Parse body if it's JSON
+    if body:
+        try:
+            body = json.loads(body)
+        except json.JSONDecodeError:
+            pass  # Keep body as-is if not valid JSON
+
+    # Log context information
+    logger.info(
+        "Function: %s, Request ID: %s, Remaining time: %dms",
+        context.function_name,
+        context.aws_request_id,
+        context.get_remaining_time_in_millis(),
+    )
+
+    # Build response
+    response_body = {
+        "message": "Hello from example-lambda3-non-prod!",
+        "function_name": context.function_name,
+        "request_id": context.aws_request_id,
+        "environment": "non-prod",
+        "event": event,
+    }
+
+    # Return API Gateway compatible response
+    return {
+        "statusCode": 200,
+        "headers": {
+            "Content-Type": "application/json",
+            "X-Request-Id": context.aws_request_id,
+        },
+        "body": json.dumps(response_body),
+    }
+

--- a/non-prod/us-west-2/example-lambda3/terragrunt.hcl
+++ b/non-prod/us-west-2/example-lambda3/terragrunt.hcl
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# LAMBDA SERVICE
+# This Terragrunt configuration deploys an AWS Lambda function using the lambda-service module
+# from the Gruntwork Infrastructure Catalog Example.
+# ---------------------------------------------------------------------------------------------------------------------
+
+terraform {
+  # You'll typically want to pin this to a particular version of your catalog repo.
+  # e.g.
+  # source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-catalog-example.git//modules/lambda-service?ref=v0.1.0"
+  source = "git::git@github.com:gruntwork-io/terragrunt-infrastructure-catalog-example.git//modules/lambda-service?ref=v1.0.0"
+
+  # Zip the Lambda source code before running Terraform commands
+  before_hook "zip_lambda_source" {
+    commands = ["apply", "plan"]
+    execute  = ["bash", "-c", "cd ${get_terragrunt_dir()}/src && zip -r ../lambda.zip ."]
+  }
+}
+
+# Include the root `root.hcl` configuration. The root configuration contains settings that are common across all
+# components and environments, such as how to configure remote state.
+include "root" {
+  path   = find_in_parent_folders("root.hcl")
+  expose = true
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# MODULE INPUTS
+# These are the variables we pass to the lambda-service module.
+# See https://github.com/gruntwork-io/terragrunt-infrastructure-catalog-example/tree/main/modules/lambda-service
+# for all available options.
+# ---------------------------------------------------------------------------------------------------------------------
+inputs = {
+  # Required: The name of the Lambda function
+  name = "example-lambda3-non-prod"
+
+  # Required: The runtime environment for the Lambda function
+  runtime = "python3.14"
+
+  # Required: The function entrypoint in your code (file.function_name format)
+  handler = "app.handler"
+
+  # Required: Path to the zipped Lambda function code (created by before_hook)
+  zip_file = "${get_terragrunt_dir()}/lambda.zip"
+
+  # Required: Memory size in MB (128-10240)
+  memory_size = 128
+
+  # Required: Timeout in seconds (1-900)
+  timeout = 30
+
+  # Tags to apply to the Lambda function
+  tags = {
+    Environment = "non-prod"
+    ManagedBy   = "terragrunt"
+  }
+}
+


### PR DESCRIPTION
This commit adds a new Lambda function configuration:
- Function name: example-lambda3
- Environment: non-prod
- Region: us-west-2
- Path: non-prod/us-west-2/example-lambda3

Files included:
- terragrunt.hcl - Terragrunt unit configuration
- src/app.py - Lambda handler source code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new Lambda (example-lambda3) in non-prod/us-west-2 with Terragrunt config and a Python handler.
> 
> - **Infrastructure**:
>   - Add `non-prod/us-west-2/example-lambda3/terragrunt.hcl` using `lambda-service` module (`ref=v1.0.0`), with pre-hook to zip source, and inputs: `name=example-lambda3-non-prod`, `runtime=python3.14`, `handler=app.handler`, `zip_file`, `memory_size=128`, `timeout=30`, and tags.
> - **Lambda Code**:
>   - Add `non-prod/us-west-2/example-lambda3/src/app.py` implementing `handler` that logs event/context, parses JSON body, and returns API Gateway–compatible 200 JSON response with message and metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 630d776ed8ae0efcd2d6de33cbae6ca743b7baad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->