### PR TITLE
chore: Getting rid of global inputs

### DIFF
--- a/root.hcl
+++ b/root.hcl
@@ -56,15 +56,3 @@ catalog {
   ]
 }
 
-# ---------------------------------------------------------------------------------------------------------------------
-# GLOBAL PARAMETERS
-# These variables apply to all configurations in this subfolder. These are automatically merged into the child
-# `terragrunt.hcl` config via the include block.
-# ---------------------------------------------------------------------------------------------------------------------
-
-# Configure root level variables that all resources can inherit. This is especially helpful with multi-account configs
-# where terraform_remote_state data sources are placed directly into the modules.
-inputs = merge(
-  local.account_vars.locals,
-  local.region_vars.locals,
-)


### PR DESCRIPTION
It was called out in #4 that we don't use these inputs anywhere in the units that are part of this template, and that it's confusing why they're here.

We should just get rid of them, and avoid recommending that users leverage any globally accessible inputs when it's a better practice to explicitly pass them down using values.
